### PR TITLE
Changes implementation in Kelas.java

### DIFF
--- a/Kelas.java
+++ b/Kelas.java
@@ -71,12 +71,24 @@ public class Kelas {
     }
 
     public boolean isChildOf(String Parent) throws ClassNotFoundException {
+
         if (this.c.getSuperclass().equals(Object.class)) {
             return false;
         }
+
         Class<?> parentClass = Class.forName(Parent);
+
         if (this.c.getSuperclass().equals(parentClass)) {
             return true;
+        }
+
+        return false;
+    }
+
+    public boolean implements(String Interface) {
+
+        if (this.c.getSuperclass().equals(Object.class)) {
+            return false;
         }
 
         for (Class<?> ifs1 : this.c.getInterfaces()) {
@@ -84,8 +96,22 @@ public class Kelas {
                 return true;
             }
         }
+
         return false;
     }
+
+    public List<Class<?>> getCommonInterfacesWith(Kelas that) {
+        List<Class<?>> list = new ArrayList<>();
+        for (Class<?> ifs1 : this.c.getInterfaces()) {
+            for (Class<?> ifs2 : that.c.getInterfaces()) {
+                if (ifs1.equals(ifs2)) {
+                    list.add(ifs1);
+                }
+            }
+        }
+        return list
+    }
+
 
     /**
      * Return all (immediate) parent supertype with another class.
@@ -95,19 +121,16 @@ public class Kelas {
      * @return A list of Class objects.
      */
     public List<Class<?>> getCommonSupertypeWith(Kelas that) {
+
         List<Class<?>> list = new ArrayList<>();
+
         if (this.c.getSuperclass().equals(that.c.getSuperclass()) &&
                 !this.c.getSuperclass().equals(Object.class)) {
             list.add(this.c.getSuperclass());
         }
 
-        for (Class<?> ifs1 : this.c.getInterfaces()) {
-            for (Class<?> ifs2 : that.c.getInterfaces()) {
-                if (ifs1.equals(ifs2)) {
-                    list.add(ifs1);
-                }
-            }
-        }
+        list.addAll(self.getCommonInterfacesWith(that))
+
         return list;
     }
 
@@ -119,21 +142,8 @@ public class Kelas {
      * @return true if a shared parent is found; false otherwise.
      */
     public boolean shareCommonSupertypeWith(Kelas ac) {
-        if (this.c.getSuperclass().equals(Object.class)) {
-            return false;
-        }
-        if (this.c.getSuperclass().equals(ac.c.getSuperclass())) {
-            return true;
-        }
-
-        for (Class<?> ifs1 : this.c.getInterfaces()) {
-            for (Class<?> ifs2 : ac.c.getInterfaces()) {
-                if (ifs1.equals(ifs2)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        List<Class<?>> commonSupertypes = this.getCommonSupertypeWith(ac);
+        return commonSupertypes.size() > 0;
     }
 
 
@@ -144,8 +154,8 @@ public class Kelas {
      * @param typeArgument The fully qualified name of the typeArgument
      * @return true if the class imlpements the interface; false otherwise.
      */
-    public boolean doesImplementGenericInterface(String name) {
-        Type[] parents = this.c.getGenericInterfaces();
+    public boolean implementsInterface(String name) {
+        Type[] parents = this.c.getInterfaces();
         for (Type ifs : parents) {
             if (ifs.getTypeName().equals(name)) {
                 return true;
@@ -161,7 +171,7 @@ public class Kelas {
     public Class getC() {
         return c;
     }
-    
+
     public boolean equals(Kelas k2) {
         return c.equals(k2.c);
     }

--- a/KelasMethods.java
+++ b/KelasMethods.java
@@ -21,48 +21,48 @@ public class KelasMethods {
      * Basic method checks
      */
     public KelasMethods arePublic(boolean allowed) {
-        Predicate<Method> pred = allowed 
-            ? m -> Modifier.isPublic(m.getModifiers()) 
+        Predicate<Method> pred = allowed
+            ? m -> Modifier.isPublic(m.getModifiers())
             : m -> !Modifier.isPublic(m.getModifiers());
         this.stream = this.stream.filter(pred);
         return this;
     }
 
     public KelasMethods arePrivate(boolean allowed) {
-        Predicate<Method> pred = allowed 
-            ? m -> Modifier.isPrivate(m.getModifiers()) 
+        Predicate<Method> pred = allowed
+            ? m -> Modifier.isPrivate(m.getModifiers())
             : m -> !Modifier.isPrivate(m.getModifiers());
         this.stream = this.stream.filter(pred);
         return this;
     }
 
     public KelasMethods areProtected(boolean allowed) {
-        Predicate<Method> pred = allowed 
-            ? m -> Modifier.isProtected(m.getModifiers()) 
+        Predicate<Method> pred = allowed
+            ? m -> Modifier.isProtected(m.getModifiers())
             : m -> !Modifier.isProtected(m.getModifiers());
         this.stream = this.stream.filter(pred);
         return this;
     }
 
     public KelasMethods areAbstract(boolean allowed) {
-        Predicate<Method> pred = allowed 
-            ? m -> Modifier.isAbstract(m.getModifiers()) 
+        Predicate<Method> pred = allowed
+            ? m -> Modifier.isAbstract(m.getModifiers())
             : m -> !Modifier.isAbstract(m.getModifiers());
         this.stream = this.stream.filter(pred);
         return this;
     }
 
     public KelasMethods areStatic(boolean allowed) {
-        Predicate<Method> pred = allowed 
-            ? m -> Modifier.isStatic(m.getModifiers()) 
+        Predicate<Method> pred = allowed
+            ? m -> Modifier.isStatic(m.getModifiers())
             : m -> !Modifier.isStatic(m.getModifiers());
         this.stream = this.stream.filter(pred);
         return this;
     }
 
     public KelasMethods areFinal(boolean allowed) {
-        Predicate<Method> pred = allowed 
-            ? m -> Modifier.isFinal(m.getModifiers()) 
+        Predicate<Method> pred = allowed
+            ? m -> Modifier.isFinal(m.getModifiers())
             : m -> !Modifier.isFinal(m.getModifiers());
         this.stream = this.stream.filter(pred);
         return this;
@@ -75,8 +75,8 @@ public class KelasMethods {
     }
 
     /*
-    * Have methods
-    */
+     * Have methods
+     */
     /**
      * Check if methods have name
      * @param name the name to check
@@ -101,7 +101,7 @@ public class KelasMethods {
      * Terminal
      */
     /**
-     * Terminal operation. 
+     * Terminal operation.
      * Collects the methods into a List.
      * @return List of methods
      */
@@ -110,7 +110,7 @@ public class KelasMethods {
     }
 
     /**
-     * Terminal operation. 
+     * Terminal operation.
      * Count the number of methods.
      * @return Number of methods
      */
@@ -119,7 +119,7 @@ public class KelasMethods {
     }
 
     /**
-     * Terminal operation. 
+     * Terminal operation.
      * Returns true if methods are absent. Returns false otherwise.
      */
     public boolean areAbsent() {
@@ -127,7 +127,7 @@ public class KelasMethods {
     }
 
     /**
-     * Terminal operation. 
+     * Terminal operation.
      * Returns true if methods are present. Returns false otherwise.
      */
     public boolean arePresent() {

--- a/KelasUtils.java
+++ b/KelasUtils.java
@@ -31,7 +31,7 @@ class KelasUtils {
      * Check for common parent
      */
     public static Check checkCommonParent(String name1, String name2)
-            throws ClassNotFoundException {
+        throws ClassNotFoundException {
         Boolean pass = false;
 
         Kelas k1 = new Kelas(name1);
@@ -53,24 +53,16 @@ class KelasUtils {
         return new Check(isChildOf, child + " does not inherit from " + parent + ".");
     }
 
-    // public static Check mustNotHaveOnlyInterfaceAsParent(String name1, String name2)
-    // throws ClassNotFoundException {
-    //     Kelas k1 = new Kelas(name1);
-    //     Kelas k2 = new Kelas(name2);
+    public static Check mustNotHaveOnlyInterfaceAsParent(String name1, String name2)
+        throws ClassNotFoundException {
+        Kelas k1 = new Kelas(name1);
+        Kelas k2 = new Kelas(name2);
 
-    //     boolean foundClass = false;
-    //     if (k1.shareCommonSupertypeWith(k2)) {
-    //         // Check if common parent of cab and car consists of only interfaces (should not)
-    //         List<Class<?>> list = k1.getCommonSupertypeWith(k2);
-    //         for (Class<?> c : list) {
-    //             if (!new Kelas(c).isInterface()) {
-    //                 foundClass = true;
-    //                 break;
-    //             }
-    //         }
-    //     }
-    //     return new Check(foundClass, name1 + " and " + name2 + " both implement an interface.");
-    // }
+        boolean foundClass = k1.getCommonInterfacesWith(k2).size() == k1.getCommonSupertypeWith(k2)
+            ? false : true;
+
+        return new Check(foundClass, name1 + " and " + name2 + " only have common interface.");
+    }
 
     // public static void mustHaveProperAbstractClassAsParent(String name1, String name2)
     //         throws ClassNotFoundException {


### PR DESCRIPTION
Replaced for loop checking for common interfaces between two classes
with an method that returns a list of common interfaces. This same
method was then used in KelasUtils to check for the presence of common parents.